### PR TITLE
Got rid of references to old_io.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unstable)]
 
-use std::old_io::Command;
-use std::old_io::fs::PathExtensions;
+use std::io::process::Command;
+use std::io::fs::PathExtensions;
 use std::os;
 use std::str;
 


### PR DESCRIPTION
I can't find docs for std::old_io, but it doesn't exist in the libraries that came with my 1.0.0-alpha compiler. The interface for std::io::process::Command and std::io::fs::PathExtensions both seem to be compatible with the way that the std::old_io versions are being used, so I'm pretty sure this is the change that's required.