### PR TITLE
add Config::get_variable

### DIFF
--- a/tests/disabled.rs
+++ b/tests/disabled.rs
@@ -69,3 +69,11 @@ fn framework() {
     assert!(lib.frameworks.contains(&"foo".to_string()));
     assert!(lib.framework_paths.contains(&PathBuf::from("/usr/lib")));
 }
+
+#[test]
+fn get_variable() {
+    let _g = LOCK.lock();
+    reset();
+    let prefix = pkg_config::Config::get_variable("foo", "prefix").unwrap();
+    assert_eq!(prefix, "/usr");
+}


### PR DESCRIPTION
This is useful in build scripts for extracting data from .pc files when the situation is more complex than just extracting some linker flags.

My particular case is for working out the path to the python interpreter so I can interrogate it for build flags.