### PR TITLE
Make the error more strongly typed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pkg-config"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/pkg-config-rs"


### PR DESCRIPTION
Allow users to distinguish between pkg-config being disabled by an environment variable, missing and genuinely failing.