### PR TITLE
Use PKG_CONFIG environment variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,8 @@ impl Config {
     }
 
     fn command(&self, name: &str, args: &[&str]) -> Command {
-        let mut cmd = Command::new("pkg-config");
+        let exe = env::var("PKG_CONFIG").unwrap_or(String::from("pkg-config"));
+        let mut cmd = Command::new(exe);
         if self.is_static(name) {
             cmd.arg("--static");
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,7 +12,9 @@ static LOCK: StaticMutex = MUTEX_INIT;
 fn reset() {
     for (k, _) in env::vars() {
         if k.contains("DYNAMIC") ||
-           k.contains("STATIC") {
+           k.contains("STATIC") ||
+           k.contains("PKG_CONFIG_ALLOW_CROSS") ||
+           k.contains("FOO_NO_PKG_CONFIG") {
             env::remove_var(&k);
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ static LOCK: StaticMutex = MUTEX_INIT;
 
 fn reset() {
     for (k, _) in env::vars() {
-        if k.contains("PKG_CONFIG") || k.contains("DYNAMIC") ||
+        if k.contains("DYNAMIC") ||
            k.contains("STATIC") {
             env::remove_var(&k);
         }


### PR DESCRIPTION
This will mimic PKG_CONF_PKG_CONFIG m4 macro.

Useful e.g. when using alternatives like pkgconf or when prefixing like x86_64-pc-linux-gnu-pkg-config (in a distro with native cross-compilation).