### PR TITLE
Fix the bug that duplicating 'cargo:' prefix in OS X framework output, and other minor bugs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,8 @@ impl Library {
     }
 
     fn parse_libs_cflags(&mut self, name: &str, output: &str, config: &Config) {
-        let parts = output.split(' ')
+        let parts = output.trim_right()
+                          .split(' ')
                           .filter(|l| l.len() > 2)
                           .map(|arg| (&arg[0..2], &arg[2..]))
                           .collect::<Vec<_>>();
@@ -402,7 +403,7 @@ impl Library {
             }
         }
 
-        let mut iter = output.split(' ');
+        let mut iter = output.trim_right().split(' ');
         while let Some(part) = iter.next() {
             if part != "-framework" {
                 continue

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl Library {
                 continue
             }
             if let Some(lib) = iter.next() {
-                let meta = format!("cargo:rustc-link-lib=framework={}", lib);
+                let meta = format!("rustc-link-lib=framework={}", lib);
                 config.print_metadata(&meta);
                 self.frameworks.push(lib.to_string());
             }


### PR DESCRIPTION
It can resolve cyndis/qmlrs#39.