### PR TITLE
Please support reading pkg-config dependencies and versions from Cargo.toml metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,8 @@ Cargo build scripts.
 """
 keywords = ["build-dependencies"]
 
+[dependencies]
+toml = "0.2"
+
 [dev-dependencies]
 lazy_static = "0.2"

--- a/README.md
+++ b/README.md
@@ -8,11 +8,21 @@ A simple library meant to be used as a build dependency with Cargo packages in
 order to use the system `pkg-config` tool (if available) to determine where a
 library is located.
 
+To use pkg-config to link to a library `foo`, with minimum version `1.2.3`, add
+the following to your `Cargo.toml`:
+
+```toml
+[package.metadata.pkg-config]
+foo = "1.2.3"
+```
+
+Then add the following to `build.rs`:
+
 ```rust
 extern crate pkg_config;
 
 fn main() {
-    pkg_config::probe_library("foo").unwrap();
+    pkg_config::probe_all().unwrap();
 }
 ```
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -22,6 +22,7 @@ fn reset() {
     }
     env::remove_var("TARGET");
     env::remove_var("HOST");
+    env::remove_var("CARGO_MANIFEST_DIR");
     env::set_var("PKG_CONFIG_PATH", &env::current_dir().unwrap().join("tests"));
 }
 
@@ -96,4 +97,51 @@ fn version() {
     let _g = LOCK.lock();
     reset();
     assert_eq!(&find("foo").unwrap().version[..], "3.10.0.SVN");
+}
+
+fn toml(path: &str) -> Result<std::collections::HashMap<String, pkg_config::Library>, pkg_config::Error> {
+    let _g = LOCK.lock();
+    reset();
+    env::set_var("CARGO_MANIFEST_DIR", &env::current_dir().unwrap().join("tests").join(path));
+    pkg_config::probe_all()
+}
+
+#[test]
+fn toml_good() {
+    let libraries = toml("toml-good").unwrap();
+    let foo = libraries.get("foo").unwrap();
+    assert_eq!(foo.version, "3.10.0.SVN");
+    let framework = libraries.get("framework").unwrap();
+    assert_eq!(framework.version, "3.10.0.SVN");
+}
+
+fn toml_err(path: &str, err_starts_with: &str) {
+    let err = toml(path).unwrap_err();
+    if let pkg_config::Error::MetadataParse(s) = err {
+        if !s.starts_with(err_starts_with) {
+            panic!("Expected error to start with: {:?}\nGot error: {:?}", err_starts_with, s);
+        }
+    } else {
+        panic!("Expected a MetadataParse error but got: {:?}", err);
+    }
+}
+
+#[test]
+fn toml_missing_file() {
+    toml_err("toml-missing-file", "Error opening");
+}
+
+#[test]
+fn toml_missing_key() {
+    toml_err("toml-missing-key", "No package.metadata.pkg-config in");
+}
+
+#[test]
+fn toml_not_table() {
+    toml_err("toml-not-table", "package.metadata.pkg-config not a table in");
+}
+
+#[test]
+fn toml_version_not_string() {
+    toml_err("toml-version-not-string", "package.metadata.pkg-config.foo not a string in");
 }

--- a/tests/toml-good/Cargo.toml
+++ b/tests/toml-good/Cargo.toml
@@ -1,0 +1,3 @@
+[package.metadata.pkg-config]
+foo = "1"
+framework = "1"

--- a/tests/toml-missing-file/no-cargo-toml-here
+++ b/tests/toml-missing-file/no-cargo-toml-here
@@ -1,0 +1,1 @@
+No Cargo.toml here

--- a/tests/toml-missing-key/Cargo.toml
+++ b/tests/toml-missing-key/Cargo.toml
@@ -1,0 +1,1 @@
+no-pkg-config-here = true

--- a/tests/toml-not-table/Cargo.toml
+++ b/tests/toml-not-table/Cargo.toml
@@ -1,0 +1,2 @@
+[package.metadata]
+pkg-config = "not a table"

--- a/tests/toml-version-not-string/Cargo.toml
+++ b/tests/toml-version-not-string/Cargo.toml
@@ -1,0 +1,2 @@
+[package.metadata.pkg-config]
+foo = 1


### PR DESCRIPTION
The pkg-config crate currently requires specifying pkg-config package names and version numbers programmatically, in `build.rs`.  pkg-config could add a function that parses pkg-config package names and version numbers from a `Cargo.toml` [metadata table](http://doc.crates.io/manifest.html#the-metadata-table-optional), `[package.metadata.pkg-config]`.  This would make that metadata declarative, rather than programmatic, which means other software could parse it as well.

For example, [docs.rs](https://docs.rs/) wants this information for documentation and building purposes.  CI tools could use this to simplify installation of packages needed to build and test a crate.  And Linux distributions could use this information to generate build dependencies.

This wouldn't require any special support in Cargo, since it just uses a metadata table.  And it wouldn't conflict with the use of mechanisms other than pkg-config to find dependencies on other platforms; this metadata would only apply to the invocation of the pkg-config crate.

If this sounds reasonable, I'd be happy to write a patch and turn this into a pull request.