### PR TITLE
Mention metadeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A simple library meant to be used as a build dependency with Cargo packages in
 order to use the system `pkg-config` tool (if available) to determine where a
 library is located.
 
+You can use this crate directly to probe for specific libraries, or use
+[metadeps](https://github.com/joshtriplett/metadeps) to declare all your
+`pkg-config` dependencies in `Cargo.toml`.
+
 # Example
 
 Find the system library named `foo`, with minimum version 1.2.3:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ A simple library meant to be used as a build dependency with Cargo packages in
 order to use the system `pkg-config` tool (if available) to determine where a
 library is located.
 
+# Example
+
+Find the system library named `foo`, with minimum version 1.2.3:
+
+```rust
+extern crate pkg_config;
+
+fn main() {
+    pkg_config::Config::new().atleast_version("1.2.3").probe("foo").unwrap();
+}
+```
+
+Find the system library named `foo`, with no version requirement (not
+recommended):
+
 ```rust
 extern crate pkg_config;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,18 @@
 //!
 //! # Example
 //!
-//! Find the system library named `foo`.
+//! Find the system library named `foo`, with minimum version 1.2.3:
+//!
+//! ```no_run
+//! extern crate pkg_config;
+//!
+//! fn main() {
+//!     pkg_config::Config::new().atleast_version("1.2.3").probe("foo").unwrap();
+//! }
+//! ```
+//!
+//! Find the system library named `foo`, with no version requirement (not
+//! recommended):
 //!
 //! ```no_run
 //! extern crate pkg_config;
@@ -46,7 +57,7 @@
 //! extern crate pkg_config;
 //!
 //! fn main() {
-//!     pkg_config::Config::new().statik(true).probe("foo").unwrap();
+//!     pkg_config::Config::new().atleast_version("1.2.3").statik(true).probe("foo").unwrap();
 //! }
 //! ```
 


### PR DESCRIPTION
Suggest using the metadeps crate to declare pkg-config dependencies in
`Cargo.toml`.

Also, update the documentation and examples to recommend always using a
minimum version requirement for libraries.