### PR TITLE
Don't force PKG_CONFIG_ALLOW_SYSTEM_LIBS=1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,8 +334,7 @@ impl Config {
             cmd.arg("--static");
         }
         cmd.args(args)
-           .args(&self.extra_args)
-           .env("PKG_CONFIG_ALLOW_SYSTEM_LIBS", "1");
+           .args(&self.extra_args);
         if let Some(ref version) = self.atleast_version {
             cmd.arg(&format!("{} >= {}", name, version));
         } else {


### PR DESCRIPTION
No idea if this change in behavior is acceptable. Seems like a bad default, though. 

Per https://github.com/alexcrichton/pkg-config-rs/issues/11#issuecomment-270317839