### PR TITLE
Prevent silently falling back to dynamic linking when static linking is explicitly requested

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,16 +430,23 @@ impl Library {
                 }
                 "-l" => {
                     self.libs.push(val.to_string());
-                    if statik && !is_system(val, &dirs) {
-                        let meta = format!("rustc-link-lib=static={}", val);
-                        config.print_metadata(&meta);
-                    } else {
-                        let meta = format!("rustc-link-lib={}", val);
-                        config.print_metadata(&meta);
-                    }
                 }
                 _ => {}
             }
+        }
+
+        for val in &self.libs {
+            if statik {
+                if is_system(val, &dirs) {
+                        panic!("The library \"{}\" is a system library, \
+                            which means it can't be linked statically!", val);
+                    }
+                    let meta = format!("rustc-link-lib=static={}", val);
+                    config.print_metadata(&meta);
+                } else {
+                    let meta = format!("rustc-link-lib={}", val);
+                    config.print_metadata(&meta);
+                }
         }
 
         let mut iter = output.trim_right().split(' ');


### PR DESCRIPTION
There were two problems with the current code:
1) if lib flags are parsed before directory flags, the full search paths are not available yet, and a library may be mistakenly deemed as a system library. Resolution: process the lib flags only after the loop, when search paths are fully known.

2) The variable `statik` is `true` when static linking has been explicitly requested. However, the `is_system` check can prevent the static branch from being selected, and dynamic link flags are passed. Because static build has been explicitly requested, it would be better just to panic with an error message instead of doing unexpected behaviour.