### PR TITLE
Added support for parsing `-Wl,` style framework flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,7 +441,13 @@ impl Library {
             }
         }
 
-        let mut iter = output.trim_right().split(' ');
+        let mut iter = output.trim_right()
+                             .split(' ')
+                             .flat_map(|arg| if arg.starts_with("-Wl,") {
+                                 arg[4..].split(',').collect()
+                             } else {
+                                 vec![arg]
+                             });
         while let Some(part) = iter.next() {
             if part != "-framework" {
                 continue

--- a/tests/framework.pc
+++ b/tests/framework.pc
@@ -11,6 +11,6 @@ Name: Valgrind
 Description: A dynamic binary instrumentation framework
 Version: 3.10.0.SVN
 Requires:
-Libs: -F${libdir} -framework foo
+Libs: -F${libdir} -framework foo -Wl,-framework,bar -Wl,-framework -Wl,baz -Wl,-framework,foobar,-framework,foobaz
 Cflags: -I${includedir}
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -80,6 +80,10 @@ fn framework() {
     reset();
     let lib = find("framework").unwrap();
     assert!(lib.frameworks.contains(&"foo".to_string()));
+    assert!(lib.frameworks.contains(&"bar".to_string()));
+    assert!(lib.frameworks.contains(&"baz".to_string()));
+    assert!(lib.frameworks.contains(&"foobar".to_string()));
+    assert!(lib.frameworks.contains(&"foobaz".to_string()));
     assert!(lib.framework_paths.contains(&PathBuf::from("/usr/lib")));
 }
 


### PR DESCRIPTION
Should solve issue #47 

`-Wl,A,B,C` is passed as `A B C` to the linker and some `.pc` files specify frameworks to link to this way: `-Wl,-framework,Framework` or  `-Wl,-framework -Wl,Framework` (instead of `-framework Framework` as is currently supported by this crate).

This PR just adds support for specifying frameworks in those other ways as well.
