### PR TITLE
Introduce target-scoped variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ fn main() {
 }
 ```
 
+# External configuration via target-scoped environment variables
+
+In cross-compilation context, it is useful to manage separately PKG_CONFIG_PATH
+and a few other variables for the `host` and the `target` platform.
+
+The supported variables are: `PKG_CONFIG_PATH`, `PKG_CONFIG_LIBDIR`, and
+`PKG_CONFIG_SYSROOT_DIR`.
+
+Each of these variables can also be supplied with certain prefixes and suffixes, in the following prioritized order:
+
+1. `<var>_<target>` - for example, `PKG_CONFIG_PATH_x86_64-unknown-linux-gnu`
+2. `<var>_<target_with_underscores>` - for example, `PKG_CONFIG_PATH_x86_64_unknown_linux_gnu`
+3. `<build-kind>_<var>` - for example, `HOST_PKG_CONFIG_PATH` or `TARGET_PKG_CONFIG_PATH`
+4. `<var>` - a plain `PKG_CONFIG_PATH`
+
+Also note that `PKG_CONFIG_ALLOW_CROSS` must always be set in cross-compilation context.
+
 # License
 
 This project is licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,9 +375,9 @@ impl Config {
         if let Ok(target) = env::var("TARGET") {
             let targetted_name = format!("{}_{}", envify(&target), name);
             match self.env_var(&targetted_name) {
-                Ok(value) => Ok(value),
-                Err(env::VarError::NotPresent) => self.env_var(name),
-                Err(e) => Err(e)
+                Ok(value) => { Ok(value) },
+                Err(env::VarError::NotPresent) => { self.env_var(name) },
+                Err(e) => { Err(e) }
             }
         } else {
             self.env_var(name)
@@ -416,6 +416,9 @@ impl Config {
         }
         if let Ok(value) = self.targetted_env_var("PKG_CONFIG_LIBDIR") {
             cmd.env("PKG_CONFIG_LIBDIR", value);
+        }
+        if let Ok(value) = self.targetted_env_var("PKG_CONFIG_SYSROOT_DIR") {
+            cmd.env("PKG_CONFIG_SYSROOT_DIR", value);
         }
         if self.print_system_libs {
             cmd.env("PKG_CONFIG_ALLOW_SYSTEM_LIBS", "1");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,9 @@ impl Config {
         if let Ok(value) = self.targetted_env_var("PKG_CONFIG_PATH") {
             cmd.env("PKG_CONFIG_PATH", value);
         }
+        if let Ok(value) = self.targetted_env_var("PKG_CONFIG_LIBDIR") {
+            cmd.env("PKG_CONFIG_LIBDIR", value);
+        }
         if self.print_system_libs {
             cmd.env("PKG_CONFIG_ALLOW_SYSTEM_LIBS", "1");
         }


### PR DESCRIPTION
This introduce target-scoped variables for PKG_CONFIG_PATH, PKG_CONFIG_LIBDIR and PKG_CONFIG_SYSROOT_DIR, mimicking cc-rs for the target-scoping conventions.