### PR TITLE
Respect pkg-config escaping rules used with --cflags and --libs.

### DIFF
--- a/tests/escape.pc
+++ b/tests/escape.pc
@@ -1,0 +1,5 @@
+Name: Escape
+Version: 4.2.0
+Description: Escape utility library
+Libs: -Llink\ path\ with\ spaces
+Cflags: -Iinclude\ path\ with\ spaces -DA=\"escaped\ string\'\ literal\" -DB=ESCAPED\ IDENTIFIER -DFOX=🦊

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -75,6 +75,21 @@ fn output_ok() {
 }
 
 #[test]
+fn escapes() {
+    let _g = LOCK.lock();
+    reset();
+    let lib = find("escape").unwrap();
+    assert!(lib.include_paths.contains(&PathBuf::from("include path with spaces")));
+    assert!(lib.link_paths.contains(&PathBuf::from("link path with spaces")));
+    assert_eq!(lib.defines.get("A"),
+               Some(&Some("\"escaped string' literal\"".to_owned())));
+    assert_eq!(lib.defines.get("B"),
+               Some(&Some("ESCAPED IDENTIFIER".to_owned())));
+    assert_eq!(lib.defines.get("FOX"),
+               Some(&Some("🦊".to_owned())));
+}
+
+#[test]
 fn framework() {
     let _g = LOCK.lock();
     reset();


### PR DESCRIPTION
* When processing output of --cflags / --libs, interpret backslash as an
  escape character preserving literal meaning of next byte and split
  output into words using unescaped whitespace characters.
* Return `Vec<u8>` from run function instead of `String`, to support cases
  where output becomes a valid UTF-8 string only after processing escapes.

Tested on Linux with:
* pkg-config: 0.29
* OpenBSD pkg-config: 0.27.1
* pkgconf: 0.28

Fixes issue #60.