### PR TITLE
Re-add AsciiExt import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@
 #![doc(html_root_url = "https://docs.rs/pkg-config/0.3")]
 #![cfg_attr(test, deny(warnings))]
 
+#[allow(unused_imports)] // Required for Rust <1.23
+use std::ascii::AsciiExt;
 use std::collections::HashMap;
 use std::env;
 use std::error;


### PR DESCRIPTION
This was removed in b5c7936aa8b78eb0faf28176fec0ce21930679fb, but breaks compatibility with Rust <1.23.

See #64 