### PR TITLE
Specify 1.13 as lowest required Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.13.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pkg-config-rs
 
 [![Build Status](https://travis-ci.org/alexcrichton/pkg-config-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/pkg-config-rs)
+[![Rust](https://img.shields.io/badge/rust-1.13%2B-blue.svg?maxAge=3600)](https://github.com/alexcrichton/pkg-config-rs/)
 
 [Documentation](https://docs.rs/pkg-config)
 
@@ -11,6 +12,8 @@ library is located.
 You can use this crate directly to probe for specific libraries, or use
 [metadeps](https://github.com/joshtriplett/metadeps) to declare all your
 `pkg-config` dependencies in `Cargo.toml`.
+
+This library requires Rust 1.13+.
 
 # Example
 


### PR DESCRIPTION
Since we're using the `?` operator, 1.13 is the lowest Rust version that
still builds.

This commit specifies 1.13 as the lowest supported Rust version and adds
a CI testing step. Changes in the minimal required version should be
considered breaking changes.

Fixes #64 