### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.3.10] - 2018-04-23
+
+### Added
+- Allow static linking of /usr/ on macOS (#42)
+- Add support for parsing `-Wl,` style framework flags (#48)
+- Parse defines in `pkg-config` output (#49)
+- Rerun on `PKG_CONFIG_PATH` changes (#50)
+- Introduce target-scoped variables (#58)
+- Respect pkg-config escaping rules used with --cflags and --libs (#61)
+
+### Changed
+- Use `?` instead of `try!()` in the codebase (#63)


### PR DESCRIPTION
Keeping a changelog makes it much easier to get an overview over the changes between two versions. https://keepachangelog.com/en/

I tried to fill in the changes in 0.3.10 from the git log. It's possible that I did not understand everything though.

I'm not sure whether adding an `[Unreleased]` section would be a good idea, since it introduces merge conflict if two user PRs add changes in parallel. I usually update the changelog of the crates I maintain right before releasing.