### PR TITLE
Don't append .lib suffix on MSVC builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,28 +485,20 @@ impl Library {
                     self.include_paths.push(PathBuf::from(val));
                 }
                 "-l" => {
-                    let libname = if is_msvc {
-                        // These are provided by the CRT with MSVC
-                        if ["m", "c", "pthread"].contains(&val) {
-                            continue;
-                        }
-
-                        // We need to convert -lfoo to foo.lib for MSVC as that
-                        // is the name of the import library
-                        format!("{}.lib", val)
-                    } else {
-                        val.to_string()
-                    };
+                    // These are provided by the CRT with MSVC
+                    if is_msvc && ["m", "c", "pthread"].contains(&val) {
+                        continue;
+                    }
 
                     if statik && is_static_available(val, &dirs) {
-                        let meta = format!("rustc-link-lib=static={}", libname);
+                        let meta = format!("rustc-link-lib=static={}", val);
                         config.print_metadata(&meta);
                     } else {
-                        let meta = format!("rustc-link-lib={}", libname);
+                        let meta = format!("rustc-link-lib={}", val);
                         config.print_metadata(&meta);
                     }
 
-                    self.libs.push(libname);
+                    self.libs.push(val.to_string());
                 }
                 "-D" => {
                     let mut iter = val.split("=");


### PR DESCRIPTION
rustc already does that itself. As such, the only difference between
MSVC and other platforms is to skip a couple of libraries that are often
wrongly added by pkg-config.


----

This didn't cause problems for me in the past because of https://github.com/gtk-rs/sys/blob/cdc7f613c2ed1e4f021a2c83d6f51469edc03eb1/glib-sys/build.rs#L66 and similar code.

Also e.g. https://github.com/alexcrichton/libz-sys/commit/d52034109e6eeb7e1fb72cadcc364f7d961b5882 should IMHO be reverted (and there the workaround for macOS is going to cause problems too)